### PR TITLE
Fix crash

### DIFF
--- a/card-manager/src/lvgl/lv_objx/lv_label.c
+++ b/card-manager/src/lvgl/lv_objx/lv_label.c
@@ -672,7 +672,7 @@ static bool lv_label_design(lv_obj_t * label, const lv_area_t * mask, lv_design_
         if(ext->no_break != 0) flag |= LV_TXT_FLAG_NO_BREAK;
         if(ext->align == LV_LABEL_ALIGN_CENTER) flag |= LV_TXT_FLAG_CENTER;
 
-		lv_draw_label(&coords, mask, style, ext->text, flag, &ext->offset);
+        if(ext->text != NULL) lv_draw_label(&coords, mask, style, ext->text, flag, &ext->offset);
     }
     return true;
 }

--- a/clock-mcu/src/firmware/clock.h
+++ b/clock-mcu/src/firmware/clock.h
@@ -74,12 +74,15 @@ void handleTime() {
 #endif 	// RTC_ENABLED
 
 	// interval for flashing time display separator colon
-	if (millis() - prevSeparatorTime >= separatorInterval) {
-		flipTimeDisplaySeparator();
+  if (millis() - prevSeparatorTime >= separatorInterval) {
+		if (mcuConfig.blink == 2 || (mcuConfig.blink == 1 && bDay)) 
+			flipTimeDisplaySeparator();
+		else
+			forceTimeDisplaySeparator();
 
 		// prepare for next interval
 		prevSeparatorTime = millis();
-	}
+	} 
 }
 
 // helper functions

--- a/clock-mcu/src/firmware/config.h
+++ b/clock-mcu/src/firmware/config.h
@@ -18,12 +18,13 @@
 struct ConfigData {
   bool twelveHMode; // True = 12h; False = 24h
   bool dayNightIndicator; // True = enable; False = disable
+  int  blink; // 0 = none; 1 only during the day; 2 always
 };
 
 extern ConfigData mcuConfig;
 
 void initConfig() {
-  mcuConfig = {true, true};
+  mcuConfig = {true, true, 2};
 }
 
 void saveConfig() {

--- a/clock-mcu/src/firmware/display.h
+++ b/clock-mcu/src/firmware/display.h
@@ -95,6 +95,11 @@ void flipTimeDisplaySeparator() {
 	bSeparatorColon = !bSeparatorColon;
 }
 
+void forceTimeDisplaySeparator() {
+  bSeparatorColon = true;
+}
+
+
 void setError() {
 	// handle the error case
 	_setChar(3, 'o', false);

--- a/clock-mcu/src/firmware/gesture.h
+++ b/clock-mcu/src/firmware/gesture.h
@@ -48,7 +48,7 @@ void setupGesture () {
 	200 LED_BOOST = 2
 	300 LED_BOOST = 3
 	*/
-	apds.setLED(0x3,0x0); //onion.io Aug 16 2018: lower LED power improves touch performance
+	apds.setLED((apds9960LedDrive_t)0x3, APDS9960_LEDBOOST_100PCNT); //onion.io Aug 16 2018: lower LED power improves touch performance, interface in the library is fucked up, if using the enum it'll be too large to fit
 
 #endif // GESTURE_ENABLED
 }
@@ -123,7 +123,7 @@ void handleGesture() {
 void handleAmbientLight() {
 	uint16_t val = 0;
 	uint16_t delta;
-	bool status;
+	bool status = false;
 
 #if GESTURE_ENABLED && GESTURE_SPARKFUN_ENABLED
 	status = apds.readAmbientLight(val);

--- a/clock-mcu/src/firmware/protocol.h
+++ b/clock-mcu/src/firmware/protocol.h
@@ -19,6 +19,7 @@
 #define CMD_SET_ALL_BUTTONS 'l'
 #define CMD_SET_DISPLAY_BRIGHTNESS 'B'
 #define CMD_SET_DAY_NIGHT_LED 'D'
+#define CMD_SET_BLINKING 'K'
 #define CMD_SET_INIT 'I'
 
 #define CMD_SEND_GESTURE 'G'
@@ -125,6 +126,12 @@ bool parseInput (char* rxData) {
       }
       saveConfig();
     break;
+
+    case CMD_SET_BLINKING:
+      mcuConfig.blink = (unsigned)(*rxData - '0') < 2 ? (*rxData - '0') : 2; 
+      saveConfig();
+    break;
+
 
     case CMD_SET_INIT:
     	sprintf(buf, "%lu", getEpoch());

--- a/clock-mcu/src/firmware/touch.h
+++ b/clock-mcu/src/firmware/touch.h
@@ -35,7 +35,7 @@ static void read_i2c_bytes(uint8_t addr, uint8_t numBytes, uint8_t *values) {
   // Wire._I2C_WRITE((byte)reg);
   // Wire.endTransmission();
 
-  Wire.requestFrom(addr, (byte)2, true);
+  Wire.requestFrom(addr, (byte)2, (byte)true);
   while (Wire.available()) {
 	  if (count < numBytes) {
 		  values[count] = Wire.read();
@@ -99,7 +99,7 @@ uint8_t handleTouch() {
 void sendButtonCommand(uint8_t buttons, uint32_t timePressed) {
   char buf[64];
 	// send button status via serial
-	sprintf(buf, "%02x%d", buttons, timePressed);
+	sprintf(buf, "%02x%lu", buttons, timePressed);
 	sendCommand(CMD_SEND_TOUCH, buf);
 }
 


### PR DESCRIPTION
Fix a crash in card manager when being run for hours. At some point in time, the lv_label's ext_attr's text is NULL and since no test are done on this value, it's crashing when it's dereferencing. The only way in the code this text can be NULL is if it's created and never assigned with lv_label_set_text (possible in the current code?).

Fix #2 